### PR TITLE
fix: copy stack from ingredient before modifying it

### DIFF
--- a/src/main/java/alexthw/ars_elemental/client/patchouli/ElementalArmorProcessor.java
+++ b/src/main/java/alexthw/ars_elemental/client/patchouli/ElementalArmorProcessor.java
@@ -4,6 +4,7 @@ package alexthw.ars_elemental.client.patchouli;
 import alexthw.ars_elemental.recipe.ElementalArmorRecipe;
 import com.hollingsworth.arsnouveau.setup.registry.DataComponentRegistry;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.Level;
@@ -35,6 +36,7 @@ public class ElementalArmorProcessor implements IComponentProcessor {
         var recipe = holder.value();
         return switch (key) {
             case "reagent" -> IVariable.wrapList(Arrays.stream(recipe.reagent().getItems())
+                    .map(ItemStack::copy)
                     .peek(i -> i.set(DataComponentRegistry.ARMOR_PERKS, i.get(DataComponentRegistry.ARMOR_PERKS).setTier(2)))
                     .map(i -> IVariable.from(i, level.registryAccess())).collect(Collectors.toList()), level.registryAccess());
             case "recipe" -> IVariable.wrap(holder.id().toString(), level.registryAccess());


### PR DESCRIPTION
Hello, I'm making this PR to this mod to add compatibility to a feature (Ingredient Deduplication) on my mod that relies heavily on modders to not modify the inner stack of those ingredients.

I would greatly appreciate it if you could accept this PR.

Thanks.
