### PR TITLE
Fixed code not generating blackstone

### DIFF
--- a/src/main/java/alexthw/ars_elemental/common/glyphs/EffectConjureTerrain.java
+++ b/src/main/java/alexthw/ars_elemental/common/glyphs/EffectConjureTerrain.java
@@ -66,7 +66,7 @@ public class EffectConjureTerrain extends ElementalAbstractEffect {
                         // If the spell contains a Smelt effect with an Amplify augment, place deepslate instead
                         toPlace = amps > 1 ? Blocks.DEEPSLATE.defaultBlockState() : Blocks.STONE.defaultBlockState();
                         if (spellStats.isRandomized() && toPlace.getBlock() == Blocks.STONE) {
-                            toPlace = switch (world.random.nextInt(5)) {
+                            toPlace = switch (world.random.nextInt(6)) {
                                 case 0 -> Blocks.DIORITE.defaultBlockState();
                                 case 1 -> Blocks.ANDESITE.defaultBlockState();
                                 case 2 -> Blocks.GRANITE.defaultBlockState();


### PR DESCRIPTION
conjure terrain -> augment -> smelt -> randomise ; did not generate blackstone, which was in the code, this was due to a possible typo in the code excluding blackstone from the range of options